### PR TITLE
change java default formatter to prettier

### DIFF
--- a/format/private/formatter_binary.bzl
+++ b/format/private/formatter_binary.bzl
@@ -14,7 +14,7 @@ TOOLS = {
     "Jsonnet": "jsonnetfmt",
     "Terraform": "terraform-fmt",
     "Kotlin": "ktfmt",
-    "Java": "java-format",
+    "Java": "prettier",
     "Scala": "scalafmt",
     "Swift": "swiftformat",
     "Go": "gofmt",


### PR DESCRIPTION
Based on the current design of rules_lint, each language can only have one formatter.  Switch the java default formatter to prettier for the onboarded project for now. Will need to take a look if it is possible to handle multiple values in the map. 