### PR TITLE
chore: disable renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "enabled": false
 }


### PR DESCRIPTION
## Summary
- Disables Renovatebot by setting `"enabled": false` in the existing `renovate.json`
- This repo is a fork of `aspect-build/rules_lint` — dependency updates should be managed upstream, not on the fork. Running Renovatebot here creates noise with PRs that will never be merged since this fork should stay in sync with upstream.